### PR TITLE
Develop gateway description

### DIFF
--- a/admin/class-wasa-kredit-checkout-admin.php
+++ b/admin/class-wasa-kredit-checkout-admin.php
@@ -52,13 +52,78 @@ class Wasa_Kredit_Checkout_Admin {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
+
+		add_filter( 'wasa_kredit_settings', array( $this, 'extend_settings' ) );
+
+		add_filter( 'woocommerce_gateway_title', array( $this, 'custom_gateway_title' ), 10, 2 );
+		add_filter( 'woocommerce_gateway_description', array( $this, 'custom_gateway_description' ), 10, 2 );
 	}
 
 	/**
-	 * Register the stylesheets for the admin area.
+	 * Used for adding additional settings that apply to all Wasa Kredit gateways.
 	 *
-	 * @since    1.0.0
+	 * @param array $settings
+	 * @return array
 	 */
+	public function extend_settings( $settings ) {
+		$settings['custom_gateway_title'] = array(
+			'title'       => __( 'Title', 'wasa-kredit-checkout' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the payment gateway <b>title</b> which the user sees during checkout.', 'wasa-kredit-checkout' ),
+			'default'     => '',
+			'placeholder' => 'Leave empty to use default.',
+		);
+
+		$settings['custom_gateway_description'] = array(
+			'title'       => __( 'Description', 'wasa-kredit-checkout' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the payment gateway <b>description</b> which the user sees during checkout.', 'wasa-kredit-checkout' ),
+			'default'     => '',
+			'placeholder' => 'Leave empty to use default.',
+		);
+
+		return $settings;
+	}
+
+	/**
+	 * Used for overriding the gateway title.
+	 *
+	 * @param string $title
+	 * @param string $gateway_id
+	 * @return string
+	 */
+	public function custom_gateway_title( $title, $gateway_id ) {
+		if ( false !== strpos( $gateway_id, 'wasa_kredit' ) ) {
+			$settings = get_option( 'wasa_kredit_settings' );
+			if ( ! empty( $settings['custom_gateway_title'] ) ) {
+				$title = $settings['custom_gateway_title'];
+			}
+		}
+		return $title;
+	}
+
+	/**
+	 * Used for overriding the gateway description.
+	 *
+	 * @param string $description
+	 * @param string $gateway_id
+	 * @return string
+	 */
+	public function custom_gateway_description( $description, $gateway_id ) {
+		if ( false !== strpos( $gateway_id, 'wasa_kredit' ) ) {
+			$settings = get_option( 'wasa_kredit_settings' );
+			if ( ! empty( $settings['custom_gateway_description'] ) ) {
+				$description = $settings['custom_gateway_description'];
+			}
+		}
+		return $$description;
+	}
+
+		/**
+		 * Register the stylesheets for the admin area.
+		 *
+		 * @since    1.0.0
+		 */
 	public function enqueue_styles() {
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -80,11 +145,11 @@ class Wasa_Kredit_Checkout_Admin {
 		);
 	}
 
-	/**
-	 * Register the JavaScript for the admin area.
-	 *
-	 * @since    1.0.0
-	 */
+		/**
+		 * Register the JavaScript for the admin area.
+		 *
+		 * @since    1.0.0
+		 */
 	public function enqueue_scripts() {
 		/**
 		 * This function is provided for demonstration purposes only.

--- a/admin/class-wasa-kredit-checkout-admin.php
+++ b/admin/class-wasa-kredit-checkout-admin.php
@@ -53,7 +53,7 @@ class Wasa_Kredit_Checkout_Admin {
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
 
-		add_filter( 'wasa_kredit_settings', array( $this, 'extend_settings' ) );
+		add_filter( 'wasa_kredit_settings', array( $this, 'extend_settings' ), 10, 2 );
 
 		add_filter( 'woocommerce_gateway_title', array( $this, 'custom_gateway_title' ), 10, 2 );
 		add_filter( 'woocommerce_gateway_description', array( $this, 'custom_gateway_description' ), 10, 2 );
@@ -65,8 +65,8 @@ class Wasa_Kredit_Checkout_Admin {
 	 * @param array $settings
 	 * @return array
 	 */
-	public function extend_settings( $settings ) {
-		$settings['custom_gateway_title'] = array(
+	public function extend_settings( $settings, $gateway_id ) {
+		$extended_settings[ $gateway_id . '_custom_gateway_title' ] = array(
 			'title'       => __( 'Title', 'wasa-kredit-checkout' ),
 			'type'        => 'text',
 			'description' => __( 'This controls the payment gateway <b>title</b> which the user sees during checkout.', 'wasa-kredit-checkout' ),
@@ -74,7 +74,7 @@ class Wasa_Kredit_Checkout_Admin {
 			'placeholder' => 'Leave empty to use default.',
 		);
 
-		$settings['custom_gateway_description'] = array(
+		$extended_settings[ $gateway_id . '_custom_gateway_description' ] = array(
 			'title'       => __( 'Description', 'wasa-kredit-checkout' ),
 			'type'        => 'text',
 			'description' => __( 'This controls the payment gateway <b>description</b> which the user sees during checkout.', 'wasa-kredit-checkout' ),
@@ -82,7 +82,10 @@ class Wasa_Kredit_Checkout_Admin {
 			'placeholder' => 'Leave empty to use default.',
 		);
 
-		return $settings;
+		// Insert the extended settings after the first setting.
+		$head = array_slice( $settings, 0, 1, true );
+		$tail = array_slice( $settings, 1, null, true );
+		return array_merge( $head, $extended_settings, $tail );
 	}
 
 	/**
@@ -95,8 +98,8 @@ class Wasa_Kredit_Checkout_Admin {
 	public function custom_gateway_title( $title, $gateway_id ) {
 		if ( false !== strpos( $gateway_id, 'wasa_kredit' ) ) {
 			$settings = get_option( 'wasa_kredit_settings' );
-			if ( ! empty( $settings['custom_gateway_title'] ) ) {
-				$title = $settings['custom_gateway_title'];
+			if ( ! empty( $settings[ $gateway_id . '_custom_gateway_title' ] ) ) {
+				$title = $settings[ $gateway_id . '_custom_gateway_title' ];
 			}
 		}
 		return $title;
@@ -112,11 +115,11 @@ class Wasa_Kredit_Checkout_Admin {
 	public function custom_gateway_description( $description, $gateway_id ) {
 		if ( false !== strpos( $gateway_id, 'wasa_kredit' ) ) {
 			$settings = get_option( 'wasa_kredit_settings' );
-			if ( ! empty( $settings['custom_gateway_description'] ) ) {
-				$description = $settings['custom_gateway_description'];
+			if ( ! empty( $settings[ $gateway_id . '_custom_gateway_description' ] ) ) {
+				$description = $settings[ $gateway_id . '_custom_gateway_description' ];
 			}
 		}
-		return $$description;
+		return $description;
 	}
 
 		/**

--- a/includes/class-wasa-kredit-checkout-payment-gateway.php
+++ b/includes/class-wasa-kredit-checkout-payment-gateway.php
@@ -194,7 +194,8 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 					),
 					'default'     => '',
 				),
-			)
+			),
+			$this->id
 		);
 	}
 

--- a/includes/class-wasa-kredit-checkout-payment-gateway.php
+++ b/includes/class-wasa-kredit-checkout-payment-gateway.php
@@ -65,133 +65,136 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 
 	public function init_form_fields() {
 		// Defines settings fields on WooCommerce > Settings > Checkout > Wasa Kredit.
-		return array(
-			'enabled'                   => array(
-				'title'   => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
-				'type'    => 'checkbox',
-				'label'   => __(
-					'Enable Wasa Kredit Checkout',
-					'wasa-kredit-checkout'
+		return apply_filters(
+			'wasa_kredit_settings',
+			array(
+				'enabled'                   => array(
+					'title'   => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
+					'type'    => 'checkbox',
+					'label'   => __(
+						'Enable Wasa Kredit Checkout',
+						'wasa-kredit-checkout'
+					),
+					'default' => 'yes',
 				),
-				'default' => 'yes',
-			),
-			'partner_id'                => array(
-				'title'       => __( 'Partner ID', 'wasa-kredit-checkout' ),
-				'type'        => 'text',
-				'description' => __(
-					'Partner ID is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'partner_id'                => array(
+					'title'       => __( 'Partner ID', 'wasa-kredit-checkout' ),
+					'type'        => 'text',
+					'description' => __(
+						'Partner ID is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'client_secret'             => array(
-				'title'       => __( 'Client secret', 'wasa-kredit-checkout' ),
-				'type'        => 'password',
-				'description' => __(
-					'Client Secret is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'client_secret'             => array(
+					'title'       => __( 'Client secret', 'wasa-kredit-checkout' ),
+					'type'        => 'password',
+					'description' => __(
+						'Client Secret is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'test_partner_id'           => array(
-				'title'       => __( 'Test Partner ID', 'wasa-kredit-checkout' ),
-				'type'        => 'text',
-				'description' => __(
-					'Test Partner ID is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'test_partner_id'           => array(
+					'title'       => __( 'Test Partner ID', 'wasa-kredit-checkout' ),
+					'type'        => 'text',
+					'description' => __(
+						'Test Partner ID is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'test_client_secret'        => array(
-				'title'       => __( 'Test Client secret', 'wasa-kredit-checkout' ),
-				'type'        => 'password',
-				'description' => __(
-					'Test Client Secret is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'test_client_secret'        => array(
+					'title'       => __( 'Test Client secret', 'wasa-kredit-checkout' ),
+					'type'        => 'password',
+					'description' => __(
+						'Test Client Secret is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'test_mode'                 => array(
-				'title'       => __( 'Test mode', 'wasa-kredit-checkout' ),
-				'type'        => 'checkbox',
-				'label'       => __( 'Enable test mode', 'wasa-kredit-checkout' ),
-				'default'     => 'yes',
-				'description' => __(
-					'This controls if the test API should be called or not. Do not use in production.',
-					'wasa-kredit-checkout'
+				'test_mode'                 => array(
+					'title'       => __( 'Test mode', 'wasa-kredit-checkout' ),
+					'type'        => 'checkbox',
+					'label'       => __( 'Enable test mode', 'wasa-kredit-checkout' ),
+					'default'     => 'yes',
+					'description' => __(
+						'This controls if the test API should be called or not. Do not use in production.',
+						'wasa-kredit-checkout'
+					),
 				),
-			),
-			'logging'                   => array(
-				'title'       => __( 'Logging', 'wasa-kredit-checkout' ),
-				'type'        => 'select',
-				'label'       => __( 'Enable logging', 'wasa-kredit-checkout' ),
-				'default'     => 'checkout',
-				'description' => __( 'Save request data to the WooCommerce System Status log.', 'wasa-kredit-checkout' ),
-				'options'     => array(
-					'no'           => __( 'Do not log requests (except errors)', 'wasa-kredit-checkout' ),
-					'monthly_cost' => __( 'Log monthly cost requests', 'wasa-kredit-checkout' ),
-					'checkout'     => __( 'Log checkout requests', 'wasa-kredit-checkout' ),
-					'all'          => __( 'Log both monthly cost & checkout requests', 'wasa-kredit-checkout' ),
+				'logging'                   => array(
+					'title'       => __( 'Logging', 'wasa-kredit-checkout' ),
+					'type'        => 'select',
+					'label'       => __( 'Enable logging', 'wasa-kredit-checkout' ),
+					'default'     => 'checkout',
+					'description' => __( 'Save request data to the WooCommerce System Status log.', 'wasa-kredit-checkout' ),
+					'options'     => array(
+						'no'           => __( 'Do not log requests (except errors)', 'wasa-kredit-checkout' ),
+						'monthly_cost' => __( 'Log monthly cost requests', 'wasa-kredit-checkout' ),
+						'checkout'     => __( 'Log checkout requests', 'wasa-kredit-checkout' ),
+						'all'          => __( 'Log both monthly cost & checkout requests', 'wasa-kredit-checkout' ),
+					),
 				),
-			),
-			'order_management'          => array(
-				'title'   => __( 'Enable Order Management', 'wasa-kredit-checkout' ),
-				'type'    => 'checkbox',
-				'label'   => __( 'Enable Wasa Kredit order capture on WooCommerce order completion.', 'wasa-kredit-checkout' ),
-				'default' => 'yes',
-			),
-			'widget_section'            => array(
-				'title' => __( 'Monthly cost widget', 'wasa-kredit-checkout' ),
-				'type'  => 'title',
-			),
-			'widget_on_product_list'    => array(
-				'title'       => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
-				'type'        => 'checkbox',
-				'label'       => __(
-					'Show monthly cost in product list',
-					'wasa-kredit-checkout'
+				'order_management'          => array(
+					'title'   => __( 'Enable Order Management', 'wasa-kredit-checkout' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable Wasa Kredit order capture on WooCommerce order completion.', 'wasa-kredit-checkout' ),
+					'default' => 'yes',
 				),
-				'description' => __(
-					'Will be shown under the price in product listings (added via the <i>woocommerce_after_shop_loop_item</i> hook).',
-					'wasa-kredit-checkout'
+				'widget_section'            => array(
+					'title' => __( 'Monthly cost widget', 'wasa-kredit-checkout' ),
+					'type'  => 'title',
 				),
-				'default'     => 'yes',
-			),
-			'widget_on_product_details' => array(
-				'title'       => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
-				'type'        => 'checkbox',
-				'label'       => __(
-					'Show monthly cost in product details',
-					'wasa-kredit-checkout'
+				'widget_on_product_list'    => array(
+					'title'       => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
+					'type'        => 'checkbox',
+					'label'       => __(
+						'Show monthly cost in product list',
+						'wasa-kredit-checkout'
+					),
+					'description' => __(
+						'Will be shown under the price in product listings (added via the <i>woocommerce_after_shop_loop_item</i> hook).',
+						'wasa-kredit-checkout'
+					),
+					'default'     => 'yes',
 				),
-				'description' => __(
-					'Will be shown between the price and the add to cart button. You can also use the shortcode [wasa_kredit_product_widget] if you want to add it manually on the product page.',
-					'wasa-kredit-checkout'
+				'widget_on_product_details' => array(
+					'title'       => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
+					'type'        => 'checkbox',
+					'label'       => __(
+						'Show monthly cost in product details',
+						'wasa-kredit-checkout'
+					),
+					'description' => __(
+						'Will be shown between the price and the add to cart button. You can also use the shortcode [wasa_kredit_product_widget] if you want to add it manually on the product page.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => 'yes',
 				),
-				'default'     => 'yes',
-			),
-			'widget_format'             => array(
-				'title'       => __( 'Widget format', 'wasa-kredit-checkout' ),
-				'type'        => 'select',
-				'label'       => __( 'The design of the montly cost widget', 'wasa-kredit-checkout' ),
-				'default'     => 'small',
-				'description' => __( 'Select the design of the monthly cost widget', 'wasa-kredit-checkout' ),
-				'options'     => array(
-					'small'         => __( 'Small', 'wasa-kredit-checkout' ),
-					'small-no-icon' => __( 'Small with no icons', 'wasa-kredit-checkout' ),
-					'large'         => __( 'Large', 'wasa-kredit-checkout' ),
-					'large-no-icon' => __( 'Large with no icons', 'wasa-kredit-checkout' ),
+				'widget_format'             => array(
+					'title'       => __( 'Widget format', 'wasa-kredit-checkout' ),
+					'type'        => 'select',
+					'label'       => __( 'The design of the montly cost widget', 'wasa-kredit-checkout' ),
+					'default'     => 'small',
+					'description' => __( 'Select the design of the monthly cost widget', 'wasa-kredit-checkout' ),
+					'options'     => array(
+						'small'         => __( 'Small', 'wasa-kredit-checkout' ),
+						'small-no-icon' => __( 'Small with no icons', 'wasa-kredit-checkout' ),
+						'large'         => __( 'Large', 'wasa-kredit-checkout' ),
+						'large-no-icon' => __( 'Large with no icons', 'wasa-kredit-checkout' ),
+					),
 				),
-			),
-			'widget_lower_threshold'    => array(
-				'title'       => __( 'Widget lower threshold', 'wasa-kredit-checkout' ),
-				'type'        => 'number',
-				'description' => __(
-					'Only display the monthly cost widget if the product price is higher thant the entered number. Leave blank to disable this feature.',
-					'wasa-kredit-checkout'
+				'widget_lower_threshold'    => array(
+					'title'       => __( 'Widget lower threshold', 'wasa-kredit-checkout' ),
+					'type'        => 'number',
+					'description' => __(
+						'Only display the monthly cost widget if the product price is higher thant the entered number. Leave blank to disable this feature.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
+			)
 		);
 	}
 
@@ -282,6 +285,7 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 	}
 
 	public function get_title() {
+		$title = $this->title;
 		if ( isset( WC()->cart ) ) {
 			$cart_totals                 = WC()->cart->get_totals();
 			$cart_total                  = $cart_totals['subtotal'] + $cart_totals['shipping_total'];
@@ -289,33 +293,30 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 			if ( ! is_wp_error( $wasa_kredit_payment_methods ) && is_array( $wasa_kredit_payment_methods ) ) {
 				foreach ( $wasa_kredit_payment_methods['payment_methods'] as $key => $value ) {
 					if ( 'rental' === $value['id'] ) {
-						return __( 'Wasa Kredit Rental', 'wasa-kredit-checkout' );
+						$title = __( 'Wasa Kredit Rental', 'wasa-kredit-checkout' );
 					}
 					if ( 'leasing' === $value['id'] ) {
-						return __( 'Wasa Kredit Leasing', 'wasa-kredit-checkout' );
+						$title = __( 'Wasa Kredit Leasing', 'wasa-kredit-checkout' );
 					}
 				}
 			}
 		}
-		return $this->title;
+		return apply_filters( 'woocommerce_gateway_title', $title, $this->id );
 	}
 
 	public function get_description() {
 		// Set custom description to display in checkout.
+
+		$desc = __( 'Financing with Wasa Kredit Checkout', 'wasa-kredit-checkout' );
 		if ( isset( WC()->cart ) ) {
 
 			$cart_totals = WC()->cart->get_totals();
 			$cart_total  = $cart_totals['subtotal'] + $cart_totals['shipping_total'];
 
 			$wasa_kredit_payment_methods = $this->get_wasa_kredit_payment_methods( $cart_total );
+			$payment_options_response    = $this->get_wasa_kredit_leasing_payment_options( $cart_total );
 
-			$payment_options_response = $this->get_wasa_kredit_leasing_payment_options( $cart_total );
-			if ( is_wp_error( $payment_options_response ) ) {
-				return;
-			}
-
-			if ( ! is_wp_error( $wasa_kredit_payment_methods ) ) {
-
+			if ( ! is_wp_error( $payment_options_response ) && ! is_wp_error( $wasa_kredit_payment_methods ) ) {
 				foreach ( $wasa_kredit_payment_methods['payment_methods'] as $key => $value ) {
 					if ( 'leasing' === $value['id'] || 'rental' === $value['id'] ) {
 						$desc = '';
@@ -346,11 +347,9 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 						$desc .= '<p>' . __( 'Proceed to select your monthly cost', 'wasa-kredit-checkout' ) . '</p>';
 					}
 				}
-
-				return $desc;
 			}
 		}
-		return __( 'Financing with Wasa Kredit Checkout', 'wasa-kredit-checkout' );
+		return apply_filters( 'woocommerce_gateway_description', $desc, $this->id );
 	}
 
 	public function get_wasa_kredit_payment_methods( $cart_total ) {

--- a/includes/class-wasa-kredit-invoice-checkout-payment-gateway.php
+++ b/includes/class-wasa-kredit-invoice-checkout-payment-gateway.php
@@ -136,7 +136,8 @@ class Wasa_Kredit_InvoiceCheckout_Payment_Gateway extends WC_Payment_Gateway {
 					'label'   => __( 'Enable Wasa Kredit order capture on WooCommerce order completion.', 'wasa-kredit-checkout' ),
 					'default' => 'yes',
 				),
-			)
+			),
+			$this->id
 		);
 	}
 

--- a/includes/class-wasa-kredit-invoice-checkout-payment-gateway.php
+++ b/includes/class-wasa-kredit-invoice-checkout-payment-gateway.php
@@ -60,80 +60,83 @@ class Wasa_Kredit_InvoiceCheckout_Payment_Gateway extends WC_Payment_Gateway {
 
 	public function init_form_fields() {
 		// Defines settings fields on WooCommerce > Settings > Checkout > Wasa Kredit.
-		return array(
-			'invoice_enabled'    => array(
-				'title'   => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
-				'type'    => 'checkbox',
-				'label'   => __(
-					'Enable Wasa Kredit Invoice Checkout',
-					'wasa-kredit-checkout'
+		return apply_filters(
+			'wasa_kredit_settings',
+			array(
+				'invoice_enabled'    => array(
+					'title'   => __( 'Enable/Disable', 'wasa-kredit-checkout' ),
+					'type'    => 'checkbox',
+					'label'   => __(
+						'Enable Wasa Kredit Invoice Checkout',
+						'wasa-kredit-checkout'
+					),
+					'default' => 'no',
 				),
-				'default' => 'no',
-			),
-			'partner_id'         => array(
-				'title'       => __( 'Partner ID', 'wasa-kredit-checkout' ),
-				'type'        => 'text',
-				'description' => __(
-					'Partner ID is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'partner_id'         => array(
+					'title'       => __( 'Partner ID', 'wasa-kredit-checkout' ),
+					'type'        => 'text',
+					'description' => __(
+						'Partner ID is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'client_secret'      => array(
-				'title'       => __( 'Client secret', 'wasa-kredit-checkout' ),
-				'type'        => 'password',
-				'description' => __(
-					'Client Secret is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'client_secret'      => array(
+					'title'       => __( 'Client secret', 'wasa-kredit-checkout' ),
+					'type'        => 'password',
+					'description' => __(
+						'Client Secret is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'test_partner_id'    => array(
-				'title'       => __( 'Test Partner ID', 'wasa-kredit-checkout' ),
-				'type'        => 'text',
-				'description' => __(
-					'Test Partner ID is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'test_partner_id'    => array(
+					'title'       => __( 'Test Partner ID', 'wasa-kredit-checkout' ),
+					'type'        => 'text',
+					'description' => __(
+						'Test Partner ID is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'test_client_secret' => array(
-				'title'       => __( 'Test Client secret', 'wasa-kredit-checkout' ),
-				'type'        => 'password',
-				'description' => __(
-					'Test Client Secret is issued by Wasa Kredit.',
-					'wasa-kredit-checkout'
+				'test_client_secret' => array(
+					'title'       => __( 'Test Client secret', 'wasa-kredit-checkout' ),
+					'type'        => 'password',
+					'description' => __(
+						'Test Client Secret is issued by Wasa Kredit.',
+						'wasa-kredit-checkout'
+					),
+					'default'     => '',
 				),
-				'default'     => '',
-			),
-			'test_mode'          => array(
-				'title'       => __( 'Test mode', 'wasa-kredit-checkout' ),
-				'type'        => 'checkbox',
-				'label'       => __( 'Enable test mode', 'wasa-kredit-checkout' ),
-				'default'     => 'yes',
-				'description' => __(
-					'This controls if the test API should be called or not. Do not use in production.',
-					'wasa-kredit-checkout'
+				'test_mode'          => array(
+					'title'       => __( 'Test mode', 'wasa-kredit-checkout' ),
+					'type'        => 'checkbox',
+					'label'       => __( 'Enable test mode', 'wasa-kredit-checkout' ),
+					'default'     => 'yes',
+					'description' => __(
+						'This controls if the test API should be called or not. Do not use in production.',
+						'wasa-kredit-checkout'
+					),
 				),
-			),
-			'logging'            => array(
-				'title'       => __( 'Logging', 'wasa-kredit-checkout' ),
-				'type'        => 'select',
-				'label'       => __( 'Enable logging', 'wasa-kredit-checkout' ),
-				'default'     => 'checkout',
-				'description' => __( 'Save request data to the WooCommerce System Status log.', 'wasa-kredit-checkout' ),
-				'options'     => array(
-					'monthly_cost' => __( 'Log monthly cost requests', 'wasa-kredit-checkout' ),
-					'checkout'     => __( 'Log checkout requests', 'wasa-kredit-checkout' ),
-					'all'          => __( 'Log both monthly cost & checkout requests', 'wasa-kredit-checkout' ),
+				'logging'            => array(
+					'title'       => __( 'Logging', 'wasa-kredit-checkout' ),
+					'type'        => 'select',
+					'label'       => __( 'Enable logging', 'wasa-kredit-checkout' ),
+					'default'     => 'checkout',
+					'description' => __( 'Save request data to the WooCommerce System Status log.', 'wasa-kredit-checkout' ),
+					'options'     => array(
+						'monthly_cost' => __( 'Log monthly cost requests', 'wasa-kredit-checkout' ),
+						'checkout'     => __( 'Log checkout requests', 'wasa-kredit-checkout' ),
+						'all'          => __( 'Log both monthly cost & checkout requests', 'wasa-kredit-checkout' ),
+					),
 				),
-			),
-			'order_management'   => array(
-				'title'   => __( 'Enable Order Management', 'wasa-kredit-checkout' ),
-				'type'    => 'checkbox',
-				'label'   => __( 'Enable Wasa Kredit order capture on WooCommerce order completion.', 'wasa-kredit-checkout' ),
-				'default' => 'yes',
-			),
+				'order_management'   => array(
+					'title'   => __( 'Enable Order Management', 'wasa-kredit-checkout' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable Wasa Kredit order capture on WooCommerce order completion.', 'wasa-kredit-checkout' ),
+					'default' => 'yes',
+				),
+			)
 		);
 	}
 
@@ -223,12 +226,12 @@ class Wasa_Kredit_InvoiceCheckout_Payment_Gateway extends WC_Payment_Gateway {
 	}
 
 	public function get_title() {
-		return __( 'Wasa Kredit Invoice', 'wasa-kredit-checkout' );
+		return apply_filters( 'woocommerce_gateway_title', __( 'Wasa Kredit Invoice', 'wasa-kredit-checkout' ), $this->id );
 	}
 
 	public function get_description() {
 		$desc  = '<p>' . __( 'Pay within 30 days', 'wasa-kredit-checkout' ) . '</p>';
 		$desc .= '<p>' . __( 'Pay after you receive the item', 'wasa-kredit-checkout' ) . '</p>';
-		return $desc;
+		return apply_filters( 'woocommerce_gateway_description', $desc, $this->id );
 	}
 }


### PR DESCRIPTION
**Let the merchant change the payment gateway title and description.**

The way it is currently set up, `wasa_kredit_settings` is shared by both gateways. As a workaround, the common settings must be prefixed unless they're meant to be shared.

![wasa+kredit+custom+title+description](https://user-images.githubusercontent.com/26507935/234805164-74100572-cd98-434f-a251-a6ae79727f83.png)
