### PR TITLE
Wrong template for leasing is used

### DIFF
--- a/includes/class-wasa-kredit-checkout-payment-gateway.php
+++ b/includes/class-wasa-kredit-checkout-payment-gateway.php
@@ -401,7 +401,7 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 					return $template;
 				}
 
-				return plugin_dir_path( __FILE__ ) . '../templates/invoice-checkout-page.php';
+				return plugin_dir_path( __FILE__ ) . '../templates/checkout-page.php';
 			}
 		}
 


### PR DESCRIPTION
Missed to update the template name to reflect the payment gateway. Currently, invoice template is used for both leasing and invoice gateway.