### PR TITLE
Only calculate monthly cost and retrieve widget for SEK

### DIFF
--- a/includes/class-wasa-kredit-checkout-list-widget.php
+++ b/includes/class-wasa-kredit-checkout-list-widget.php
@@ -34,25 +34,30 @@ class Wasa_Kredit_Checkout_List_Widget {
 			return;
 		}
 
-		// Hooks.
-		add_action(
-			'woocommerce_before_shop_loop',
-			array( $this, 'save_product_prices' ),
-			10
-		);
+		// Only Swedish currency is supported.
+		if ( 'SEK' === get_woocommerce_currency() ) {
+			// Hooks.
+			add_action(
+				'woocommerce_before_shop_loop',
+				array( $this, 'save_product_prices' ),
+				10
+			);
 
-		add_action(
-			'woocommerce_shortcode_before_products_loop',
-			array( $this, 'save_product_prices_shortcodes' ),
-			10
-		);
+			add_action(
+				'woocommerce_shortcode_before_products_loop',
+				array( $this, 'save_product_prices_shortcodes' ),
+				10
+			);
 
-		add_action(
-			'woocommerce_after_shop_loop_item',
-			array( $this, 'display_leasing_price_per_product' ),
-			9
-		);
+			add_action(
+				'woocommerce_after_shop_loop_item',
+				array( $this, 'display_leasing_price_per_product' ),
+				9
+			);
+		}
 
+		// Do not prevent shortcode from being registered due to currency mismatch as they should still be registered
+		// but their output should be empty if the currency is not support. Therefore, check currency within the registration function.
 		add_shortcode(
 			'wasa_kredit_list_widget',
 			array(
@@ -67,15 +72,19 @@ class Wasa_Kredit_Checkout_List_Widget {
 	 */
 	public function display_leasing_price_per_product() {
 
-		// Adds financing info betweeen price and Add to cart button.
-		global $product;
-
 		if ( 'yes' !== $this->settings['widget_on_product_list'] ) {
 			return;
 		}
 
-		$monthly_cost = 0;
+		// Only Swedish currency is supported.
+		if ( 'SEK' !== get_woocommerce_currency() ) {
+			return;
+		}
 
+		// Adds financing info between price and Add to cart button.
+		global $product;
+
+		$monthly_cost = 0;
 		if ( isset( $GLOBALS['product_leasing_prices'] ) &&
 		isset( $GLOBALS['product_leasing_prices'][ $product->get_id() ] ) ) {
 			$monthly_cost = $GLOBALS['product_leasing_prices'][ $product->get_id() ];
@@ -103,9 +112,10 @@ class Wasa_Kredit_Checkout_List_Widget {
 			return;
 		}
 
-		$payload['items'] = array();
-		// Payload will contain all products with price, currency and id.
 		$current_currency = get_woocommerce_currency();
+
+		// Payload will contain all products with price, currency and id.
+		$payload['items'] = array();
 
 		global $wp_query;
 		$loop = $wp_query;

--- a/includes/class-wasa-kredit-checkout-product-widget.php
+++ b/includes/class-wasa-kredit-checkout-product-widget.php
@@ -50,6 +50,11 @@ class Wasa_Kredit_Checkout_Product_Widget {
 						'product_id'     => 'ADDON_PRICE',
 					);
 
+					// Only Swedish country and currency is supported.
+					if ( 'SEK' !== get_woocommerce_currency() ) {
+						return;
+					}
+
 					$monthly_cost_response = Wasa_Kredit_WC()->api->calculate_monthly_cost( $payload );
 
 					if ( ! is_wp_error( $monthly_cost_response ) ) {
@@ -202,7 +207,10 @@ class Wasa_Kredit_Checkout_Product_Widget {
 
 			return false;
 		}
-
+		// Only Swedish country and currency is supported.
+		if ( 'SEK' !== get_woocommerce_currency() ) {
+			return false;
+		}
 		$response = Wasa_Kredit_WC()->api->get_monthly_cost_widget( $price, $this->widget_format );
 
 		if ( ! is_wp_error( $response ) ) {


### PR DESCRIPTION
Check if the currency is SEK before retrieving monthly cost and outputting the widget as Wasa only support the Swedish currency. However, we still want the widgets to be registered even if the currency is not supported, therefore, the check is nested within the widget registration function.