### PR TITLE
Add compatibility with WooCommerce's HPOS

### DIFF
--- a/classes/class-wasa-kredit-checkout-callbacks.php
+++ b/classes/class-wasa-kredit-checkout-callbacks.php
@@ -95,6 +95,7 @@ class Wasa_Kredit_Callbacks {
 					'Wasa Kredit sent order update for id ' . $wasa_order_id . ' -> ' .
 					$order_status . ' but order was in state ' . $order->get_status() . ', ignoring update.'
 				);
+				$order->save();
 				return;
 			}
 
@@ -120,6 +121,8 @@ class Wasa_Kredit_Callbacks {
 		} else {
 			$order->add_order_note( __( 'Failed to find a mapping for Wasa Kredit status', 'wasa-kredit-checkout' ) . ' "' . $order_status . '"' );
 		}
+		
+		$order->save();
 	}
 
 	public function order_update_stats_authorize( WP_REST_Request $request ) {

--- a/classes/class-wasa-kredit-checkout-callbacks.php
+++ b/classes/class-wasa-kredit-checkout-callbacks.php
@@ -100,6 +100,7 @@ class Wasa_Kredit_Callbacks {
 
 			$order->set_transaction_id( $wasa_order_id );
 			$order->add_order_note( __( 'Woocommerce associated order with wasa kredit id', 'wasa-kredit-checkout' ) . ' "' . $wasa_order_id . '"' );
+			$order->save();
 		} else {
 			$order = $orders[0];
 		}
@@ -121,7 +122,6 @@ class Wasa_Kredit_Callbacks {
 			$order->add_order_note( __( 'Failed to find a mapping for Wasa Kredit status', 'wasa-kredit-checkout' ) . ' "' . $order_status . '"' );
 		}
 		
-		$order->save();
 	}
 
 	public function order_update_stats_authorize( WP_REST_Request $request ) {

--- a/classes/class-wasa-kredit-checkout-callbacks.php
+++ b/classes/class-wasa-kredit-checkout-callbacks.php
@@ -95,7 +95,6 @@ class Wasa_Kredit_Callbacks {
 					'Wasa Kredit sent order update for id ' . $wasa_order_id . ' -> ' .
 					$order_status . ' but order was in state ' . $order->get_status() . ', ignoring update.'
 				);
-				$order->save();
 				return;
 			}
 

--- a/classes/class-wasa-kredit-checkout-callbacks.php
+++ b/classes/class-wasa-kredit-checkout-callbacks.php
@@ -98,7 +98,7 @@ class Wasa_Kredit_Callbacks {
 				return;
 			}
 
-			update_post_meta( $order->get_id(), '_transaction_id', $wasa_order_id );
+			$order->set_transaction_id( $wasa_order_id );
 			$order->add_order_note( __( 'Woocommerce associated order with wasa kredit id', 'wasa-kredit-checkout' ) . ' "' . $wasa_order_id . '"' );
 		} else {
 			$order = $orders[0];

--- a/classes/class-wasa-kredit-checkout-order-management.php
+++ b/classes/class-wasa-kredit-checkout-order-management.php
@@ -76,7 +76,6 @@ class Wasa_Kredit_Checkout_Order_Management {
 		if ( is_wp_error( $wasa_status ) ) {
 			$note = __( 'Error when trying to get Wasa Kredit order status.', 'wasa-kredit-checkout' );
 			$order->add_order_note( $note );
-			$order->save();
 			return;
 		}
 
@@ -98,8 +97,6 @@ class Wasa_Kredit_Checkout_Order_Management {
 			$note = __( 'Error: You changed order status to ', 'wasa-kredit-checkout' ) . $order_status . __( ' but the order could not be changed at Wasa Kredit.', 'wasa-kredit-checkout' );
 			$order->add_order_note( $note );
 		}
-		
-		$order->save();
 	}
 
 	function no_credential_notice() {

--- a/classes/class-wasa-kredit-checkout-order-management.php
+++ b/classes/class-wasa-kredit-checkout-order-management.php
@@ -76,6 +76,7 @@ class Wasa_Kredit_Checkout_Order_Management {
 		if ( is_wp_error( $wasa_status ) ) {
 			$note = __( 'Error when trying to get Wasa Kredit order status.', 'wasa-kredit-checkout' );
 			$order->add_order_note( $note );
+			$order->save();
 			return;
 		}
 
@@ -96,8 +97,9 @@ class Wasa_Kredit_Checkout_Order_Management {
 		} else {
 			$note = __( 'Error: You changed order status to ', 'wasa-kredit-checkout' ) . $order_status . __( ' but the order could not be changed at Wasa Kredit.', 'wasa-kredit-checkout' );
 			$order->add_order_note( $note );
-			$order->save();
 		}
+		
+		$order->save();
 	}
 
 	function no_credential_notice() {

--- a/wasa-kredit-checkout.php
+++ b/wasa-kredit-checkout.php
@@ -223,7 +223,21 @@ if ( ! class_exists( 'Wasa_Kredit_Checkout' ) ) {
 			require_once WASA_KREDIT_CHECKOUT_PLUGIN_PATH . '/classes/requests/get/class-wasa-kredit-checkout-request-validate-financed-invoice-amount.php';
 			require_once WASA_KREDIT_CHECKOUT_PLUGIN_PATH . '/classes/requests/get/class-wasa-kredit-checkout-request-validate-financed-leasing-amount.php';
 
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
+
 			$this->loader = new Wasa_Kredit_Checkout_Loader();
+		}
+
+		/**
+		 * Declare compatibility with WooCommerce features.
+		 *
+		 * @return void
+		 */
+		public function declare_wc_compatibility() {
+			// Declare HPOS compatibility.
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
 		}
 
 		/**


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and `update_meta_data` is still used, WooCommerce will warn about directly modifying internal meta data.

Note:
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.

**If approved, please squash and merge.**

Task: https://app.clickup.com/t/865cjj5t7