### PR TITLE
Optionally display widgets without enabling gateway

### DIFF
--- a/includes/class-wasa-kredit-checkout-list-widget.php
+++ b/includes/class-wasa-kredit-checkout-list-widget.php
@@ -30,10 +30,6 @@ class Wasa_Kredit_Checkout_List_Widget {
 
 		$this->widget_lower_threshold = isset( $this->settings['widget_lower_threshold'] ) ? $this->settings['widget_lower_threshold'] : '';
 
-		if ( 'no' === $this->settings['enabled'] ) {
-			return;
-		}
-
 		// Only Swedish currency is supported.
 		if ( 'SEK' === get_woocommerce_currency() ) {
 			// Hooks.

--- a/includes/class-wasa-kredit-checkout-product-widget.php
+++ b/includes/class-wasa-kredit-checkout-product-widget.php
@@ -75,9 +75,8 @@ class Wasa_Kredit_Checkout_Product_Widget {
 		// Extend the Wasa Kredit settings with product page settings.
 		add_filter( 'wasa_kredit_settings', array( $this, 'extend_settings' ) );
 
-		if ( 'yes' === $this->settings['enabled'] ) {
-			add_action( 'woocommerce_single_product_summary', array( $this, 'product_widget_hook' ), 1 );
-		}
+		// Display the widget on the product page.
+		add_action( 'woocommerce_single_product_summary', array( $this, 'product_widget_hook' ), 1 );
 
 	}
 


### PR DESCRIPTION
Whether the widget should be displayed is still managed through the plugin's settings "Show monthly cost in product list" and "Show monthly cost in product details", however, now you don't have to enable the plugin.

https://app.clickup.com/t/8694bwf2v